### PR TITLE
Fix return type of RootDiskUUID on OSX

### DIFF
--- a/internal/sys/disk_darwin.go
+++ b/internal/sys/disk_darwin.go
@@ -11,7 +11,7 @@ func RootDiskUUID() (uuid.UUID, error) {
 	devno, err := fsevents.DeviceForPath("/")
 
 	if err != nil {
-		return "", err
+		return uuid.Nil, err
 	}
 
 	uuidStr := fsevents.GetDeviceUUID(devno)


### PR DESCRIPTION
It wont compile without it.